### PR TITLE
Handle storage permissions for folder picker

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,13 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29" />
 
     <queries>
         <intent>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -301,6 +301,9 @@
     <string name="max_song_cache_size">Max song cache size</string>
     <string name="clear_song_cache">Clear song cache</string>
     <string name="size_used">%s used</string>
+    <string name="select_download_folder">Select download folder</string>
+    <string name="error_storage_permission_denied">Storage permission denied</string>
+    <string name="error_folder_selection_failed">Failed to select folder</string>
 
     <string name="privacy">Privacy</string>
     <string name="listen_history">Listen history</string>


### PR DESCRIPTION
## Summary
- declare storage permissions for legacy and API33+
- request proper permissions before folder picker in storage settings
- show errors when permission denied or selection fails

## Testing
- `./gradlew lint` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b39b5d50832fa135b9d74357068b